### PR TITLE
Rename play_note function to be more consistent

### DIFF
--- a/include/yboard.h
+++ b/include/yboard.h
@@ -79,7 +79,7 @@ class YBoardV2 {
      * played. The duration parameter is a long integer representing the duration of
      * the note in milliseconds.
      */
-    void play_note(unsigned int freq, unsigned long duration);
+    void play_note_background(unsigned int freq, unsigned long duration);
 
     // LEDs
     static constexpr int led_pin = 5;

--- a/src/yboard.cpp
+++ b/src/yboard.cpp
@@ -93,6 +93,6 @@ void YBoardV2::setup_timer() {
 
 ////////////////////////////// Speaker/Tones /////////////////////////////////////
 
-void YBoardV2::play_note(unsigned int freq, unsigned long duration) {
+void YBoardV2::play_note_background(unsigned int freq, unsigned long duration) {
     tone(this->tone_pin, freq, duration);
 }


### PR DESCRIPTION
Changed the name from `play_note` to `play_note_background` to be consistent with the v3 library and make the nature of the function to be more explicit. Related to https://github.com/y-board/y-board-v3/pull/12.